### PR TITLE
BaSP-TG-46: timesheets form order and tasks routes letter 'a' for 'A' modification.

### DIFF
--- a/src/Components/Tasks/index.js
+++ b/src/Components/Tasks/index.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import styles from './tasks.module.css';
 import Task from './Task/index';
 import Modal from './Modal/index';
-import Logo from '../../assets/trash.png';
+import Logo from '../../Assets/trash.png';
 
 const Tasks = () => {
   const [tasks, saveTasks] = useState([]);

--- a/src/Components/TimeSheets/Form/index.js
+++ b/src/Components/TimeSheets/Form/index.js
@@ -198,6 +198,26 @@ function Form() {
             </select>
           </div>
           <div className={styles.box}>
+            <label>Project</label>
+            <select
+              name="project"
+              required
+              value={inputTimeSheetValue.project}
+              onChange={onChangeInputValue}
+            >
+              <option value="" disabled hidden>
+                Select a project
+              </option>
+              {projects.map((project) => {
+                return (
+                  <option key={project._id} value={project._id}>
+                    {project.name}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+          <div className={styles.box}>
             <label>Employee</label>
             <select
               name="employee"
@@ -213,26 +233,6 @@ function Form() {
                 return (
                   <option key={index} value={selectedEmployee._id}>
                     {selectedEmployee.name}
-                  </option>
-                );
-              })}
-            </select>
-          </div>
-          <div className={styles.box}>
-            <label>Project</label>
-            <select
-              name="project"
-              required
-              value={inputTimeSheetValue.project}
-              onChange={onChangeInputValue}
-            >
-              <option value="" disabled hidden>
-                Select a project
-              </option>
-              {projects.map((project) => {
-                return (
-                  <option key={project._id} value={project._id}>
-                    {project.name}
                   </option>
                 );
               })}


### PR DESCRIPTION
I have to chenge task route 'assets' for 'Assets' because it was the only one that call assets that way and throws an error.