### PR TITLE
BaSP-TG-135: fix in-login data loading

### DIFF
--- a/src/Components/Employee/EditEmployee/index.js
+++ b/src/Components/Employee/EditEmployee/index.js
@@ -42,7 +42,7 @@ const EditEmployee = () => {
         lastName: currentEmployee.lastName,
         phone: currentEmployee.phone,
         email: currentEmployee.email,
-        repeatEmail: currentEmployee.repeatEmail
+        repeatEmail: currentEmployee.email
       });
     }
   }, [employees.length, id]);

--- a/src/redux/auth/reducer.js
+++ b/src/redux/auth/reducer.js
@@ -11,7 +11,8 @@ const INITIAL_STATE = {
   email: null,
   role: null,
   isLoading: true,
-  error: null
+  error: null,
+  logged: false
 };
 
 const reducer = (state = INITIAL_STATE, action) => {
@@ -35,7 +36,8 @@ const reducer = (state = INITIAL_STATE, action) => {
         isLoading: false,
         role: action.payload.role,
         email: action.payload.email,
-        error: null
+        error: null,
+        logged: true
       };
     case LOGOUT_SUCCESS:
       return {
@@ -43,7 +45,8 @@ const reducer = (state = INITIAL_STATE, action) => {
         isLoading: false,
         role: null,
         email: null,
-        error: null
+        error: null,
+        logged: false
       };
     default:
       return state;

--- a/src/redux/auth/thunks.js
+++ b/src/redux/auth/thunks.js
@@ -1,4 +1,4 @@
-import { loginPending, loginError, logoutPending, logoutError } from './actions';
+import { loginPending, loginError, logoutPending, logoutError, setLoggedOut } from './actions';
 
 import { signInWithEmailAndPassword, signOut } from 'firebase/auth';
 import { auth } from '../../helpers/firebase';
@@ -28,6 +28,7 @@ export const logout = () => {
     return signOut(auth)
       .then(() => {
         sessionStorage.clear();
+        dispatch(setLoggedOut());
       })
       .catch((error) => {
         return dispatch(logoutError(error.toString()));

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -11,7 +11,7 @@ const PrivateRoute = lazy(() => import('./PrivateRoute'));
 const AuthRoutes = lazy(() => import('./auth'));
 
 const Routes = () => {
-  const authenticated = useSelector((store) => store.auth.role);
+  const authenticated = useSelector((store) => store.auth.logged);
   const dispatch = useDispatch();
 
   useEffect(() => {


### PR DESCRIPTION
The app was not sending the logoff and the employee data was not being loaded correctly on the first render because the old token was still there.